### PR TITLE
v0.2.1 hotfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,11 @@ This bot uses [Discord.js](https://discord.js.org/#/) and the [Commando framewor
 ## Commands
 
 ```shell
-building|b {name|code} query
 calendar|cal query
 course|c course-code
 exam|e course-code
 info|i [key] # Providing no key lists all available keys
 infoedit|ie {add|edit|delete} key [value]
-textbook|tb {title|courses} query
 ```
 
 ## Setup

--- a/commands/school/building.js
+++ b/commands/school/building.js
@@ -12,6 +12,7 @@ module.exports = class Building extends Command {
       memberName: 'building',
       description: 'Lookup building directions by code or name',
       guildOnly: false,
+      hidden: true,
       throttling: {
         usages: 2,
         duration: 10,

--- a/commands/school/textbook.js
+++ b/commands/school/textbook.js
@@ -12,6 +12,7 @@ module.exports = class Textbook extends Command {
       memberName: 'textbook',
       description: 'Search for a textbook by title in the Bookstore',
       guildOnly: false,
+      hidden: true,
       throttling: {
         usages: 2,
         duration: 10,


### PR DESCRIPTION
Hide `building` and `textbook` commands as https://nikel.ml API seems to be acting up.